### PR TITLE
fix(ZBuffer): don't raise an exception

### DIFF
--- a/lib/src/main/java/io/github/nonmilk/coffee/grinder/render/ZBuffer.java
+++ b/lib/src/main/java/io/github/nonmilk/coffee/grinder/render/ZBuffer.java
@@ -25,7 +25,10 @@ public class ZBuffer {
 
     public boolean draw(int x, int y, float z) {
         if (x >= width || y >= height || x < 0 || y < 0) {
-            throw new IllegalArgumentException("Accessing coordinate outside of dimensions");
+            return false;
+            // FIXME "not so good" design choice
+            // throw new IllegalArgumentException("Accessing coordinate outside of
+            // dimensions");
         }
 
         int posInArray = y * width + x;


### PR DESCRIPTION
it's more consistent and easier this way. it's probably better to raise an exception, but our architecture is too bad at the moment to control all the places in the code to control this